### PR TITLE
fix the root dir location when building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-07-06
+
+### Fixed
+
+- A previous iteration of the package moved the rootDir configuration in tsconfig.json
+to `./`, since it was complaining about the ambiguity of the root directory following
+the bootstrapping of the first tests. Because we set that, the build output was rerouted
+under cjs/src and esm/src respectively, instead of being available directly under cjs
+and esm. The package.json makes this assumption in its "main" and "exports" declarations,
+and so that assumption was broken and the package was unusable.
+
 ## [0.2.0] - 2025-07-06
 
 ### Changed

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "noEmit": false,
+    "rootDir": "src",
     "sourceMap": true
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
- tsconfig.build.json required an update following the change in rootDir
of tsconfig.json.
