### PR TITLE
bootstrapping integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,19 @@
       "devDependencies": {
         "@biomejs/biome": "^2.0.6",
         "@infra-blocks/checks": "^0.2.6",
+        "@infra-blocks/node-console-logger": "^0.3.1",
         "@infra-blocks/test": "^0.4.0",
+        "@infra-blocks/types": "^0.10.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.10",
         "c8": "^10.1.3",
+        "dotenv": "^17.0.1",
         "lefthook": "^1.11.16",
-        "mocha": "^11.7.1",
+        "mocha": "^11.6.0",
+        "radash": "^12.1.1",
         "tsx": "^4.20.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "zod": "^3.25.74"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1353,6 +1358,40 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@infra-blocks/node-console-logger": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@infra-blocks/node-console-logger/-/node-console-logger-0.3.1.tgz",
+      "integrity": "sha512-lXA3W7XPzn4eJYvPNsgIKzYjpyjATyLtHo7w0tpDV0X5FTil26LzkyYVH8irtTGu23usoQZCLAt/7m0asTOcyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@infra-blocks/logger-interface": "^0.2.0",
+        "@infra-blocks/types": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@infra-blocks/node-console-logger/node_modules/@infra-blocks/logger-interface": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@infra-blocks/logger-interface/-/logger-interface-0.2.0.tgz",
+      "integrity": "sha512-x3AKlGzeyKN7IiHXwUpqS1C78HTR+vhglxN9vgy9rZgzBlK2A1/MGKtrFFLjMxoS95Sy0Y8AXlIIEqffBYodsg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@infra-blocks/node-console-logger/node_modules/@infra-blocks/types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@infra-blocks/types/-/types-0.8.0.tgz",
+      "integrity": "sha512-z65dypIlVX5z7dDi7ZlfmsZ4R221jLYu8ioDEEIAsU7caaONvnasx8trz65VX1zApGax55YiEbhwbKjdcZnSLg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@infra-blocks/null-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@infra-blocks/null-logger/-/null-logger-0.1.1.tgz",
@@ -1387,6 +1426,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@infra-blocks/retry/node_modules/@infra-blocks/types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@infra-blocks/types/-/types-0.6.0.tgz",
+      "integrity": "sha512-DJpE7ua4Q/sVdEoF8qfSp0qj7+mHMPlV26SMbqTziuJjKNNOyOLVDERslbMAzDJukXpn/6fAcvt7mxWtaWY2rQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@infra-blocks/test": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@infra-blocks/test/-/test-0.4.0.tgz",
@@ -1406,9 +1454,10 @@
       }
     },
     "node_modules/@infra-blocks/types": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@infra-blocks/types/-/types-0.6.0.tgz",
-      "integrity": "sha512-DJpE7ua4Q/sVdEoF8qfSp0qj7+mHMPlV26SMbqTziuJjKNNOyOLVDERslbMAzDJukXpn/6fAcvt7mxWtaWY2rQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@infra-blocks/types/-/types-0.10.0.tgz",
+      "integrity": "sha512-jsVy2goxZnas5A/6FluEOp6vQlq/aAK3azzGZssTHN31j08B5LDZMISSrhyGq21hDds2hNCxSu5TgES4iSp6HQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=18.0.0"
@@ -2549,6 +2598,19 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.1.tgz",
+      "integrity": "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3182,9 +3244,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
-      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.6.0.tgz",
+      "integrity": "sha512-i0JVb+OUBqw63X/1pC3jCyJsqYisgxySBbsQa8TKvefpA1oEnw7JXxXnftfMHRsw7bEEVGRtVlHcDYXBa7FzVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3378,6 +3440,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/radash": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/radash/-/radash-12.1.1.tgz",
+      "integrity": "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/randombytes": {
@@ -3901,6 +3973,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.74",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.74.tgz",
+      "integrity": "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,14 +40,19 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
     "@infra-blocks/checks": "^0.2.6",
+    "@infra-blocks/node-console-logger": "^0.3.1",
     "@infra-blocks/test": "^0.4.0",
+    "@infra-blocks/types": "^0.10.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.10",
     "c8": "^10.1.3",
+    "dotenv": "^17.0.1",
     "lefthook": "^1.11.16",
-    "mocha": "^11.7.1",
+    "mocha": "^11.6.0",
+    "radash": "^12.1.1",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod": "^3.25.74"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/test/integration/.env.test
+++ b/test/integration/.env.test
@@ -1,0 +1,7 @@
+# Those are here so the AWS SDK doesn't try to be smart and use default configuration of the user
+# outside the scope of this project.
+AWS_ACCESS_KEY_ID=TESTACCESSKEYID
+AWS_SECRET_ACCESS_KEY=TEST-SECRET-ACCESS-KEY
+AWS_REGION=yo-ass-1
+# This URL is used to both start the container and connect to it later.
+DYNAMODB_ENDPOINT_URL=http://localhost:30500

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,0 +1,12 @@
+name: aws.dynamodb.tests
+
+services:
+  db:    
+    container_name: aws.dynamodb.tests.db
+    image: "amazon/dynamodb-local:latest"
+    ports:
+      - "${DYNAMODB_PORT}:8000"
+
+networks:
+  default:
+    name: aws.dynamodb.tests

--- a/test/integration/mocha.d.ts
+++ b/test/integration/mocha.d.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "./test-config.ts";
+import type { Logger } from "@infra-blocks/logger-interface";
+
+declare module "mocha" {
+  export interface Context {
+    logger: Logger;
+    config: TestConfig;
+  }
+}

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -1,7 +1,86 @@
-before("setup", () => {
-  console.log("before all tests hook");
+import * as childProcess from "node:child_process";
+import type { Logger } from "@infra-blocks/logger-interface";
+import { ConsoleLogger } from "@infra-blocks/node-console-logger";
+import type { EnvironmentVariables } from "@infra-blocks/types";
+import { omit } from "radash";
+import { DynamoDbClient } from "../../src/client.js";
+import {
+  getTestConfig,
+  injectTestConfig,
+  type TestConfig,
+} from "./test-config.js";
+
+const CURRENT_DIR = import.meta.dirname;
+
+function runSync(
+  command: string,
+  options: childProcess.ExecSyncOptions & { logger: Logger },
+): void {
+  const { logger } = options;
+  logger.info(`running command: ${command}`);
+  childProcess.execSync(command, {
+    ...omit(options, ["logger"]),
+  });
+}
+
+function dockerComposeUp(params: {
+  env?: EnvironmentVariables;
+  logger: Logger;
+}): void {
+  runSync("docker compose up --build -d", { ...params, cwd: CURRENT_DIR });
+}
+
+function dockerComposeDown(params: { logger: Logger }): void {
+  runSync("docker compose down", { ...params, cwd: CURRENT_DIR });
+}
+
+async function init(params: {
+  config: TestConfig;
+  logger: Logger;
+}): Promise<void> {
+  const { logger, config } = params;
+
+  const { DYNAMODB_ENDPOINT_URL } = config;
+  const dynamoDbPort = new URL("", DYNAMODB_ENDPOINT_URL).port;
+
+  logger.info("starting services");
+  dockerComposeUp({
+    env: {
+      DYNAMODB_PORT: dynamoDbPort,
+      PATH: process.env.PATH,
+    },
+    logger,
+  });
+  const dynamoDbClient = DynamoDbClient.create({
+    dynamodb: { endpoint: DYNAMODB_ENDPOINT_URL },
+    logger,
+  });
+  await dynamoDbClient.ready().on("attempt", ({ attempt }) => {
+    logger.info(`attempt #${attempt} at connecting to DynamoDB`);
+  });
+}
+
+function tearDown(params: { logger: Logger }): void {
+  const { logger } = params;
+  logger.info("stopping services");
+  dockerComposeDown({ logger });
+}
+
+before("test suite setup", async function () {
+  injectTestConfig();
+  const config = getTestConfig();
+  const logger = ConsoleLogger.create({
+    name: "test:integration",
+    level: config.TEST_LOG_LEVEL,
+  });
+  await init({ logger, config });
+
+  this.config = config;
+  this.logger = logger;
+  logger.info("setup complete");
 });
 
-after("tearing down", () => {
-  console.log("after all tests hook");
+after("test suite teardown", function () {
+  tearDown({ logger: this.logger });
+  this.logger.info("teardown complete");
 });

--- a/test/integration/test-config.ts
+++ b/test/integration/test-config.ts
@@ -1,0 +1,24 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+const schema = z.object({
+  DYNAMODB_ENDPOINT_URL: z.string().describe("The DynamoDB endpoint URL."),
+  TEST_LOG_LEVEL: z
+    // TODO: export this array from logger interface.
+    .enum(["trace", "debug", "info", "warn", "error"])
+    .describe("The test harness log level")
+    .default("info"),
+});
+
+export type TestConfig = z.infer<typeof schema>;
+
+export function injectTestConfig() {
+  dotenv.config({
+    path: `${import.meta.dirname}/.env.test`,
+    quiet: true,
+  });
+}
+
+export function getTestConfig(): TestConfig {
+  return schema.parse(process.env);
+}


### PR DESCRIPTION
- Had to lower the mocha version down from 11.7.0 to 11.6.0, since
the latest update seems to break the import.meta stuff (the ts
files were interpreted as cjs despite the package.json type). 11.6.0
works as expected.
