### PR TITLE
Condition expression functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2025-07-13
+
+### Added
+
+- `ConditionExpression` `contains` and `size` functions. The `size` function is peculiar
+in that, contrary to the other functions, it does not return a boolean but rather a
+number that should be used within the context of a higher order expression. Therefore,
+we introduced a new type: `FunctionExpression`, that is returned by the factory and
+that is different than `ConditionExpression` (so it cannot be used alone with a `putItem`
+command, for example). The only place right now where it can be embedded is within the
+`contains` function, where it can be called as such: `contains(Tata, size(Toto))`.
+
 ## [0.10.0] - 2025-07-12
 
 ### Added
@@ -124,6 +136,12 @@ intuitive.
 - Initial release of the package! Move the implementation work in progress from another
 project to here.
 
+[0.11.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.3.1...v0.3.2

--- a/src/commands/expressions/condition.ts
+++ b/src/commands/expressions/condition.ts
@@ -1,7 +1,26 @@
-import type { AttributePath, AttributeType } from "../../types.js";
+import type {
+  AttributePath,
+  AttributeType,
+  AttributeValue,
+} from "../../types.js";
 import type { AttributeNames } from "../attributes/names.js";
 import type { AttributeValues } from "../attributes/values.js";
 import type { Expression } from "./expression.js";
+
+export class FunctionExpression implements Expression {
+  private readonly inner: Expression;
+  constructor(params: { inner: Expression }) {
+    const { inner } = params;
+    this.inner = inner;
+  }
+
+  stringify(params: {
+    attributeNames: AttributeNames;
+    attributeValues: AttributeValues;
+  }): string {
+    return this.inner.stringify(params);
+  }
+}
 
 /**
  *
@@ -47,6 +66,10 @@ export class ConditionExpression implements Expression {
   }
 }
 
+/**
+ *
+ * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions
+ */
 export function attributeNotExists(
   attribute: AttributePath,
 ): ConditionExpression {
@@ -90,6 +113,35 @@ export function beginsWith(
     inner: {
       stringify: ({ attributeNames, attributeValues }) => {
         return `begins_with(${attributeNames.substitute(attribute)}, ${attributeValues.reference(value)})`;
+      },
+    },
+  });
+}
+
+export function contains(
+  attribute: AttributePath,
+  value: AttributeValue | FunctionExpression,
+): ConditionExpression {
+  return new ConditionExpression({
+    inner: {
+      stringify: ({ attributeNames, attributeValues }) => {
+        if (value instanceof FunctionExpression) {
+          return `contains(${attributeNames.substitute(attribute)}, ${value.stringify({ attributeNames, attributeValues })})`;
+        }
+        return `contains(${attributeNames.substitute(attribute)}, ${attributeValues.reference(value)})`;
+      },
+    },
+  });
+}
+
+// This is the only factory that doesn't return a ConditionExpression. This is because the size function
+// does not return a boolean value, rather a number of items. This also means that it can be used in more
+// complex expressions, such as in a comparison: Toto > size(Tata).
+export function size(attribute: AttributePath): FunctionExpression {
+  return new FunctionExpression({
+    inner: {
+      stringify: ({ attributeNames }) => {
+        return `size(${attributeNames.substitute(attribute)})`;
       },
     },
   });

--- a/test/unit/commands/expressions/condition.spec.ts
+++ b/test/unit/commands/expressions/condition.spec.ts
@@ -8,7 +8,9 @@ import {
   attributeType,
   beginsWith,
   ConditionExpression,
+  contains,
   not,
+  size,
 } from "../../../../src/index.js";
 
 describe("commands.expressions.condition-expression", () => {
@@ -71,6 +73,41 @@ describe("commands.expressions.condition-expression", () => {
         const reference = match[2];
         expect(substitution).to.equal(attributeNames.substitute(attribute));
         expect(reference).to.equal(attributeValues.reference(value));
+      });
+    });
+    describe(contains.name, () => {
+      it("should work with regular attribute path and value", () => {
+        const attribute = "test.attribute";
+        const value = "substring";
+        const condition = contains(attribute, value);
+        const attributeNames = AttributeNames.create();
+        const attributeValues = AttributeValues.create();
+        const result = condition.stringify({ attributeNames, attributeValues });
+        const match = checkNotNull(/contains\((#.+),\s*(:.+)\)/.exec(result));
+        const substitution = match[1];
+        const reference = match[2];
+        expect(substitution).to.equal(attributeNames.substitute(attribute));
+        expect(reference).to.equal(attributeValues.reference(value));
+      });
+      it("should work with the size function as value", () => {
+        const attribute = "test.attribute";
+        const sizedAttribute = "test.sized_attribute";
+        const value = size(sizedAttribute);
+        const condition = contains(attribute, value);
+        const attributeNames = AttributeNames.create();
+        const attributeValues = AttributeValues.create();
+        const result = condition.stringify({ attributeNames, attributeValues });
+        const match = checkNotNull(
+          /contains\((#.+),\s*size\((#.+)\)\)/.exec(result),
+          "mismatched result %s",
+          result,
+        );
+        const substitution = match[1];
+        const sizeSubstitution = match[2];
+        expect(substitution).to.equal(attributeNames.substitute(attribute));
+        expect(sizeSubstitution).to.equal(
+          attributeNames.substitute(sizedAttribute),
+        );
       });
     });
     describe("logical operators", () => {


### PR DESCRIPTION
- contains and size. Size introduces a new concept where the function
needs to be contained within a higher order expression, since it is
a function that does not return a boolean.
- contains has been identified as the only function that can also
wrap the size function. Operators will also have that feature but
they are non existent at the moment.
