### PR TITLE
update set refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2025-07-21
+
+### Changed
+
+- The syntax used to create `SetAction`s has changed to be more conventional with
+the remaining action factory functions. Instead of being called like 
+`set(attribute(<name>)).to(value(<value>))`, it has been streamlined to
+`set(attribute(<name>), value(<value>))`. Addition and subtraction expressions are
+also supported: `set(attribute(<name>), value(<value>), "+", value(<value>))`, where
+`"+"` can be substituted by `"-"`.
+
 ## [0.22.0] - 2025-07-21
 
 ### Changed
@@ -299,6 +310,7 @@ intuitive.
 - Initial release of the package! Move the implementation work in progress from another
 project to here.
 
+[0.23.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.19.0...v0.20.0

--- a/src/commands/expressions/update/remove.ts
+++ b/src/commands/expressions/update/remove.ts
@@ -33,7 +33,6 @@ export class RemoveAction implements IUpdateAction {
  *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.DELETE
  */
-
 export function remove(path: AttributeOperand): UpdateAction {
   return RemoveAction.from(path);
 }

--- a/test/integration/commands/update-item.spec.ts
+++ b/test/integration/commands/update-item.spec.ts
@@ -49,7 +49,8 @@ describe(DynamoDBClient.name, () => {
         // Maybe use a generic type in the field that defaults to record?
         partitionKey: { name: "pk", value: putItemParams.item.pk },
         update: [
-          set(attribute("stuff.kebab-field")).to(
+          set(
+            attribute("stuff.kebab-field"),
             ifNotExists(attribute("default.add"), value(0)),
           ),
           remove(attribute("stuff.removeMe")),

--- a/test/unit/commands/expressions/update/set.spec.ts
+++ b/test/unit/commands/expressions/update/set.spec.ts
@@ -13,7 +13,7 @@ describe("commands.expressions.update.set", () => {
       const path = "attr.path";
       const operand = "attr.operand";
       const { match, names } = actionMatch({
-        action: set(attribute(path)).to(attribute(operand)),
+        action: set(attribute(path), attribute(operand)),
         matcher: /(#\S+)\s+=\s+(#\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -23,7 +23,7 @@ describe("commands.expressions.update.set", () => {
       const path = "attr.path";
       const operand = 42;
       const { match, names, values } = actionMatch({
-        action: set(attribute(path)).to(value(operand)),
+        action: set(attribute(path), value(operand)),
         matcher: /(#\S+)\s+=\s+(:\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -33,7 +33,8 @@ describe("commands.expressions.update.set", () => {
       const path = "attr.path";
       const operand = "attr.operand";
       const { match, names } = actionMatch({
-        action: set(attribute(path)).to(
+        action: set(
+          attribute(path),
           ifNotExists(attribute(path), attribute(operand)),
         ),
         matcher: /(#\S+)\s+=\s+if_not_exists\((#\S+),\s+(#\S+)\)/,
@@ -47,7 +48,7 @@ describe("commands.expressions.update.set", () => {
       const lhs = "attr.lhs";
       const rhs = "attr.rhs";
       const { match, names } = actionMatch({
-        action: set(attribute(path)).to(attribute(lhs)).plus(attribute(rhs)),
+        action: set(attribute(path), attribute(lhs), "+", attribute(rhs)),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+\+\s+(#\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -59,7 +60,7 @@ describe("commands.expressions.update.set", () => {
       const lhs = "attr.lhs";
       const rhs = 42;
       const { match, names, values } = actionMatch({
-        action: set(attribute(path)).to(attribute(lhs)).plus(value(rhs)),
+        action: set(attribute(path), attribute(lhs), "+", value(rhs)),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+\+\s+(:\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -72,9 +73,12 @@ describe("commands.expressions.update.set", () => {
       const rhs = "attr.rhs";
       const defaultValue = 42;
       const { match, names, values } = actionMatch({
-        action: set(attribute(path))
-          .to(attribute(lhs))
-          .plus(ifNotExists(attribute(rhs), value(defaultValue))),
+        action: set(
+          attribute(path),
+          attribute(lhs),
+          "+",
+          ifNotExists(attribute(rhs), value(defaultValue)),
+        ),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+\+\s+if_not_exists\((#\S+),\s+(:\S+)\)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -87,7 +91,7 @@ describe("commands.expressions.update.set", () => {
       const lhs = "attr.lhs";
       const rhs = "attr.rhs";
       const { match, names } = actionMatch({
-        action: set(attribute(path)).to(attribute(lhs)).minus(attribute(rhs)),
+        action: set(attribute(path), attribute(lhs), "-", attribute(rhs)),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+-\s+(#\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -99,7 +103,7 @@ describe("commands.expressions.update.set", () => {
       const lhs = "attr.lhs";
       const rhs = 42;
       const { match, names, values } = actionMatch({
-        action: set(attribute(path)).to(attribute(lhs)).minus(value(rhs)),
+        action: set(attribute(path), attribute(lhs), "-", value(rhs)),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+-\s+(:\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(path));
@@ -112,9 +116,12 @@ describe("commands.expressions.update.set", () => {
       const rhs = "attr.rhs";
       const defaultValue = 42;
       const { match, names, values } = actionMatch({
-        action: set(attribute(path))
-          .to(attribute(lhs))
-          .minus(ifNotExists(attribute(rhs), value(defaultValue))),
+        action: set(
+          attribute(path),
+          attribute(lhs),
+          "-",
+          ifNotExists(attribute(rhs), value(defaultValue)),
+        ),
         matcher: /(#\S+)\s+=\s+(#\S+)\s+-\s+if_not_exists\((#\S+),\s+(:\S+)\)/,
       });
       expect(match[1]).to.equal(names.substitute(path));


### PR DESCRIPTION
- Reviewed the syntax of `set` to make it more like the other functions.
- It does not rely on a builder syntax anymore, but rather function
overloading to distinguish between simple assignment and expression
assignement.
