### PR TITLE
raw path, implicit path and path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-08-04
+
+### Added
+
+- Support for `RawPath` and path normalization. This feature introduce the idea of using
+unwrapped types directly with the query expression API in certain circumstances. In specific,
+this change introduce the ability to use `string`s instead of `Path`s in APIs where `Path`s
+are required. This is accomplish with the use of a union type as input: `RawPath`, and a
+normalization function behind the scene that normalizes the input to a `Path` object:
+`Path.normalize`. Let's take the `remove` update action as an example. Before, the user
+*had* to pass in a `Path` object using the `path` function, as such:
+`update: [remove(path("the.attribute.))]`. With this change, the user can pass the attribute
+path directly as a string: `update: [remove("the.attribute")]`. Affected APIs are:
+  - The `attributeExists` condition function.
+  - The `attributeNotExists` condition function.
+  - The `attributeType` condition function.
+  - All update actions (`set`, `remove`, `add`, `delete`) and the
+  `ifNotExists` update action function.
+
+
 ## [0.28.0] - 2025-07-31
 
 ### Changed
@@ -374,6 +394,7 @@ intuitive.
 - Initial release of the package! Move the implementation work in progress from another
 project to here.
 
+[0.29.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/infra-blocks/ts-aws-dynamodb/compare/v0.25.0...v0.26.0

--- a/src/commands/expressions/condition/functions.ts
+++ b/src/commands/expressions/condition/functions.ts
@@ -1,5 +1,5 @@
 import type { NativeBinary, NativeString, NativeType } from "../../../types.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { Value } from "../operands/value.js";
 import { ConditionExpression } from "./expression.js";
 import type { Size } from "./size.js";
@@ -7,30 +7,31 @@ import type { Size } from "./size.js";
 /**
  * Returns a condition that uses the `attribute_exists` function.
  *
- * @param attribute - The attribute path to check for existence.
+ * @param rawPath - The attribute path to check for existence.
  * @returns A {@link ConditionExpression} that evaluates to true if the provided attribute path exists.
  *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions
  */
-export function attributeExists(attribute: Path): ConditionExpression {
+export function attributeExists(rawPath: RawPath): ConditionExpression {
+  const path = Path.normalize(rawPath);
   return ConditionExpression.from({
-    stringify: ({ names }) =>
-      `attribute_exists(${attribute.substitute({ names })})`,
+    stringify: ({ names }) => `attribute_exists(${path.substitute({ names })})`,
   });
 }
 
 /**
  * Returns a condition that uses the `attribute_not_exists` function.
  *
- * @param attribute - The attribute path to check for non-existence.
+ * @param rawPath - The attribute path to check for non-existence.
  * @returns A {@link ConditionExpression} that evaluates to true if the provided attribute path does not exist.
  *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions
  */
-export function attributeNotExists(attribute: Path): ConditionExpression {
+export function attributeNotExists(rawPath: RawPath): ConditionExpression {
+  const path = Path.normalize(rawPath);
   return ConditionExpression.from({
     stringify: ({ names }) =>
-      `attribute_not_exists(${attribute.substitute({ names })})`,
+      `attribute_not_exists(${path.substitute({ names })})`,
   });
 }
 
@@ -45,12 +46,13 @@ export function attributeNotExists(attribute: Path): ConditionExpression {
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions
  */
 export function attributeType(
-  attribute: Path,
+  attribute: RawPath,
   type: Value<NativeType>,
 ): ConditionExpression {
+  const path = Path.normalize(attribute);
   return ConditionExpression.from({
     stringify: ({ names, values }) =>
-      `attribute_type(${attribute.substitute({ names })}, ${type.substitute({ values })})`,
+      `attribute_type(${path.substitute({ names })}, ${type.substitute({ values })})`,
   });
 }
 
@@ -81,6 +83,7 @@ export function beginsWith(
   });
 }
 
+// TODO: type better on the lhs/rhs?
 /**
  * This type aggregates the types of operands that can be used as the first operand of the {@link contains} function.
  */

--- a/src/commands/expressions/operands/path.ts
+++ b/src/commands/expressions/operands/path.ts
@@ -3,6 +3,29 @@ import type { AttributeNames } from "../../attributes/names.js";
 import type { IOperand } from "./type.js";
 
 /**
+ * This type represents the types that can implicitly be used
+ * as path operands.
+ */
+export type ImplicitPath = AttributePath;
+
+/**
+ * This type aggregates the types that can be used as path operands.
+ *
+ * An {@link ImplicitPath} can be used in APIs that expect a {@link RawPath}
+ * just as well as an explicit {@link Path} instance.
+ *
+ * Using the {@link attributeExists} function as example, the following two
+ * invokations are equivalent:
+ * ```ts
+ * // Explicit path.
+ * attributeExists(path("foo.bar.baz"));
+ * // Implicit path.
+ * attributeExists("foo.bar.baz");
+ * ```
+ */
+export type RawPath = AttributePath | Path;
+
+/**
  * Represents an attribute path operand in an expression.
  *
  * When this operand is stringified, it first registers the
@@ -12,13 +35,40 @@ import type { IOperand } from "./type.js";
 export class Path implements IOperand {
   private readonly path: AttributePath;
 
-  constructor(path: AttributePath) {
+  private constructor(path: AttributePath) {
     this.path = path;
   }
 
   substitute(params: { names: AttributeNames }): string {
     const { names } = params;
     return names.substitute(this.path);
+  }
+
+  /**
+   * @private
+   */
+  static from(path: AttributePath): Path {
+    return new Path(path);
+  }
+
+  /**
+   * Turns {@link RawPath} path into a {@link Path} instance.
+   *
+   * If the provided path is already a {@link Path}, it will be returned as-is.
+   * Otherwise, a new {@link Path} instance will be created from the provided
+   * argument.
+   *
+   * @param loosePath - The path to return as is or convert to a {@link Path} instance.
+   *
+   * @returns The normalized {@link Path} instance.
+   *
+   * @private
+   */
+  static normalize(loosePath: RawPath): Path {
+    if (loosePath instanceof Path) {
+      return loosePath;
+    }
+    return Path.from(loosePath);
   }
 }
 
@@ -30,5 +80,5 @@ export class Path implements IOperand {
  * @returns A new {@link Path} instance for the provided path.
  */
 export function path(path: AttributePath): Path {
-  return new Path(path);
+  return Path.from(path);
 }

--- a/src/commands/expressions/update/add.ts
+++ b/src/commands/expressions/update/add.ts
@@ -1,14 +1,13 @@
 import type { NativeNumber, NativeSet } from "../../../types.js";
 import type { AttributeNames } from "../../attributes/names.js";
 import type { AttributeValues } from "../../attributes/values.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { Value } from "../operands/value.js";
 import type { IUpdateAction, UpdateAction } from "./action.js";
 import type { UpdateExpressionClauses } from "./clauses.js";
 
 type NumberOrSet = NativeNumber | NativeSet;
 
-// Note: the first operand *must* be an attribute name, and the second operand *must* be a value.
 export class AddAction implements IUpdateAction {
   private readonly path: Path;
   private readonly value: Value<NumberOrSet>;
@@ -48,7 +47,7 @@ export class AddAction implements IUpdateAction {
  *
  * This action only supports numbers and sets as values.
  *
- * @param path - The attribute path to modify.
+ * @param rawPath - The attribute path to modify.
  * @param value - The value to add to the attribute.
  *
  * @returns An {@link AddAction} that will add the value to the attribute at the specified path.
@@ -56,6 +55,7 @@ export class AddAction implements IUpdateAction {
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD
  */
 
-export function add(path: Path, value: Value<NumberOrSet>): UpdateAction {
+export function add(rawPath: RawPath, value: Value<NumberOrSet>): UpdateAction {
+  const path = Path.normalize(rawPath);
   return AddAction.from({ path, value });
 }

--- a/src/commands/expressions/update/delete.ts
+++ b/src/commands/expressions/update/delete.ts
@@ -1,7 +1,7 @@
 import type { NativeSet } from "../../../types.js";
 import type { AttributeNames } from "../../attributes/names.js";
 import type { AttributeValues } from "../../attributes/values.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { Value } from "../operands/value.js";
 import type { IUpdateAction, UpdateAction } from "./action.js";
 import type { UpdateExpressionClauses } from "./clauses.js";
@@ -44,7 +44,7 @@ export class DeleteAction implements IUpdateAction {
  * This operation only supports sets as values. The resulting set will be the original set minus the
  * provided subset.
  *
- * @param path - The attribute path to modify.
+ * @param rawPath - The attribute path to modify.
  * @param value - The value to remove from the attribute.
  *
  * @returns A {@link DeleteAction} that will remove the subset from the attribute.
@@ -52,6 +52,10 @@ export class DeleteAction implements IUpdateAction {
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.DELETE
  */
 
-export function deleteFrom(path: Path, value: Value<NativeSet>): UpdateAction {
+export function deleteFrom(
+  rawPath: RawPath,
+  value: Value<NativeSet>,
+): UpdateAction {
+  const path = Path.normalize(rawPath);
   return DeleteAction.from({ path, value });
 }

--- a/src/commands/expressions/update/if-not-exists.ts
+++ b/src/commands/expressions/update/if-not-exists.ts
@@ -1,6 +1,6 @@
 import type { AttributeNames } from "../../attributes/names.js";
 import type { AttributeValues } from "../../attributes/values.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { IOperand, Operand } from "../operands/type.js";
 
 export class IfNotExistsOperand implements IOperand {
@@ -23,8 +23,9 @@ export class IfNotExistsOperand implements IOperand {
 }
 
 export function ifNotExists(
-  path: Path,
+  rawPath: RawPath,
   defaultValue: Operand,
 ): IfNotExistsOperand {
+  const path = Path.normalize(rawPath);
   return new IfNotExistsOperand({ path, defaultValue });
 }

--- a/src/commands/expressions/update/remove.ts
+++ b/src/commands/expressions/update/remove.ts
@@ -1,5 +1,5 @@
 import type { AttributeNames } from "../../attributes/names.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { IUpdateAction, UpdateAction } from "./action.js";
 import type { UpdateExpressionClauses } from "./clauses.js";
 
@@ -27,12 +27,13 @@ export class RemoveAction implements IUpdateAction {
 /**
  * Returns an action that will remove the specific attribute at the provided path.
  *
- * @param path - The path of the attribute to remove.
+ * @param rawPath - The path of the attribute to remove.
  *
  * @returns A {@link RemoveAction} corresponding to the path provided.
  *
  * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.DELETE
  */
-export function remove(path: Path): UpdateAction {
+export function remove(rawPath: RawPath): UpdateAction {
+  const path = Path.normalize(rawPath);
   return RemoveAction.from(path);
 }

--- a/src/commands/expressions/update/set.ts
+++ b/src/commands/expressions/update/set.ts
@@ -1,6 +1,6 @@
 import type { AttributeNames } from "../../attributes/names.js";
 import type { AttributeValues } from "../../attributes/values.js";
-import type { Path } from "../operands/path.js";
+import { Path, type RawPath } from "../operands/path.js";
 import type { Operand } from "../operands/type.js";
 import type { IUpdateAction, UpdateAction } from "./action.js";
 import type { UpdateExpressionClauses } from "./clauses.js";
@@ -61,21 +61,21 @@ export class SetAction implements IUpdateAction {
 }
 
 // TODO: increment/decrement utilities built on top of the assignments.
-export function set(path: Path, operand: SetOperand): UpdateAction;
+export function set(rawPath: RawPath, operand: SetOperand): UpdateAction;
 export function set(
-  path: Path,
+  rawPath: RawPath,
   operand: SetOperand,
   operator: SetOperator,
   secondOperand: SetOperand,
 ): UpdateAction;
 export function set(
-  path: Path,
+  rawPath: RawPath,
   operand: SetOperand,
   operator?: SetOperator,
   secondOperand?: SetOperand,
 ): UpdateAction {
   return SetAction.from({
-    path,
+    path: Path.normalize(rawPath),
     operand,
     operator,
     secondOperand,

--- a/test/unit/commands/expressions/condition/functions.spec.ts
+++ b/test/unit/commands/expressions/condition/functions.spec.ts
@@ -24,6 +24,15 @@ describe("commands.expressions.condition.functions", () => {
       const attributeSubstitution = match[1];
       expect(attributeSubstitution).to.equal(names.substitute(attribute));
     });
+    it("should work with an implicit path", () => {
+      const attribute = "test.attribute";
+      const { match, names } = expressionMatch({
+        expression: attributeExists(attribute),
+        matcher: /attribute_exists\((#\S+)\)/,
+      });
+      const attributeSubstitution = match[1];
+      expect(attributeSubstitution).to.equal(names.substitute(attribute));
+    });
   });
   describe(attributeNotExists.name, () => {
     it("should not compile with a value", () => {
@@ -34,6 +43,15 @@ describe("commands.expressions.condition.functions", () => {
       const attribute = "test.attribute";
       const { match, names } = expressionMatch({
         expression: attributeNotExists(path(attribute)),
+        matcher: /attribute_not_exists\((#\S+)\)/,
+      });
+      const attributeSubstitution = match[1];
+      expect(attributeSubstitution).to.equal(names.substitute(attribute));
+    });
+    it("should work with an implicit path", () => {
+      const attribute = "test.attribute";
+      const { match, names } = expressionMatch({
+        expression: attributeNotExists(attribute),
         matcher: /attribute_not_exists\((#\S+)\)/,
       });
       const attributeSubstitution = match[1];
@@ -57,6 +75,17 @@ describe("commands.expressions.condition.functions", () => {
         const lhs = "test.attribute";
         const { match, names, values } = expressionMatch({
           expression: attributeType(path(lhs), value(type)),
+          matcher: /attribute_type\((#\S+),\s*(:\S+)\)/,
+        });
+        const lhsSubstitution = match[1];
+        const rhsSubstitution = match[2];
+        expect(lhsSubstitution).to.equal(names.substitute(lhs));
+        expect(rhsSubstitution).to.equal(values.substitute(type));
+      });
+      it(`should work with an implicit path and type ${type}`, () => {
+        const lhs = "test.attribute";
+        const { match, names, values } = expressionMatch({
+          expression: attributeType(lhs, value(type)),
           matcher: /attribute_type\((#\S+),\s*(:\S+)\)/,
         });
         const lhsSubstitution = match[1];

--- a/test/unit/commands/expressions/update/add.spec.ts
+++ b/test/unit/commands/expressions/update/add.spec.ts
@@ -5,32 +5,30 @@ import { actionMatch } from "./action-match.js";
 describe("commands.expressions.update.add", () => {
   describe(add.name, () => {
     it("should not compile with an attribute name and a string", () => {
-      // @ts-expect-error
+      // @ts-expect-error A string is not a valid rhs operand for add.
       add(path("name"), value("toto"));
     });
     it("should not compile with an attribute name and a boolean", () => {
-      // @ts-expect-error
+      // @ts-expect-error A boolean is not a valid rhs operand for add.
       add(path("name"), value(true));
     });
     it("should not compile with an attribute name and null", () => {
-      // @ts-expect-error
+      // @ts-expect-error Null is not a valid rhs operand for add.
       add(path("name"), value(null));
     });
     it("should not compile with an attribute name and undefined", () => {
-      // @ts-expect-error
+      // @ts-expect-error Undefined is not a valid rhs operand for add.
       add(path("name"), value(undefined));
     });
     it("should not compile with an attribute name and a record", () => {
-      // Records are maps, which aren't sets or numbers.
-      // @ts-expect-error
+      // @ts-expect-error A record is not a valid rhs operand for add.
       add(path("name"), value({}));
     });
     it("should not compile with an attribute name and an array", () => {
-      // Arrays are lists, which aren't sets or numbers.
-      // @ts-expect-error
+      // @ts-expect-error An array is not a valid rhs operand for add.
       add(path("name"), value([]));
     });
-    it("should work with an attribute name and a number", () => {
+    it("should work with a path and a number", () => {
       const { match, names, values } = actionMatch({
         action: add(path("attr.name"), value(42)),
         matcher: /(#\S+)\s+(:\S+)/,
@@ -38,10 +36,27 @@ describe("commands.expressions.update.add", () => {
       expect(match[1]).to.equal(names.substitute("attr.name"));
       expect(match[2]).to.equal(values.substitute(42));
     });
-    it("should work with an attribute name and a set", () => {
+    it("should work with an implicit path and a number", () => {
+      const { match, names, values } = actionMatch({
+        action: add("attr.name", value(42)),
+        matcher: /(#\S+)\s+(:\S+)/,
+      });
+      expect(match[1]).to.equal(names.substitute("attr.name"));
+      expect(match[2]).to.equal(values.substitute(42));
+    });
+    it("should work with a path name and a set", () => {
       const added = new Set(["toto", "tata", "tutu"]);
       const { match, names, values } = actionMatch({
         action: add(path("attr.name"), value(added)),
+        matcher: /(#\S+)\s+(:\S+)/,
+      });
+      expect(match[1]).to.equal(names.substitute("attr.name"));
+      expect(match[2]).to.equal(values.substitute(added));
+    });
+    it("should work with an implicit path name and a set", () => {
+      const added = new Set(["toto", "tata", "tutu"]);
+      const { match, names, values } = actionMatch({
+        action: add("attr.name", value(added)),
         matcher: /(#\S+)\s+(:\S+)/,
       });
       expect(match[1]).to.equal(names.substitute("attr.name"));

--- a/test/unit/commands/expressions/update/delete.spec.ts
+++ b/test/unit/commands/expressions/update/delete.spec.ts
@@ -4,40 +4,47 @@ import { actionMatch } from "./action-match.js";
 
 describe("commands.expressions.update.delete", () => {
   describe(deleteFrom.name, () => {
-    it("should not compile with an attribute name and a string", () => {
-      // @ts-expect-error
+    it("should not compile with a path and a string", () => {
+      // @ts-expect-error A string is not a valid rhs operand for delete.
       deleteFrom(path("name"), value("toto"));
     });
-    it("should not compile with an attribute name and a number", () => {
-      // @ts-expect-error
+    it("should not compile with a path and a number", () => {
+      // @ts-expect-error A number is not a valid rhs operand for delete.
       deleteFrom(path("name"), value(42));
     });
-    it("should not compile with an attribute name and a boolean", () => {
-      // @ts-expect-error
+    it("should not compile with a path and a boolean", () => {
+      // @ts-expect-error A boolean is not a valid rhs operand for delete.
       deleteFrom(path("name"), value(true));
     });
-    it("should not compile with an attribute name and null", () => {
-      // @ts-expect-error
+    it("should not compile with a path and null", () => {
+      // @ts-expect-error Null is not a valid rhs operand for delete.
       deleteFrom(path("name"), value(null));
     });
-    it("should not compile with an attribute name and undefined", () => {
-      // @ts-expect-error
+    it("should not compile with a path and undefined", () => {
+      // @ts-expect-error Undefined is not a valid rhs operand for delete.
       deleteFrom(path("name"), value(undefined));
     });
-    it("should not compile with an attribute name and a record", () => {
-      // Records are maps, which aren't sets or numbers.
-      // @ts-expect-error
+    it("should not compile with a path and a record", () => {
+      // @ts-expect-error A record is not a valid rhs operand for delete.
       deleteFrom(path("name"), value({}));
     });
-    it("should not compile with an attribute name and an array", () => {
-      // Arrays are lists, which aren't sets or numbers.
-      // @ts-expect-error
+    it("should not compile with a path and an array", () => {
+      // @ts-expect-error An array is not a valid rhs operand for delete.
       deleteFrom(path("name"), value([]));
     });
-    it("should work with an attribute name and a set", () => {
+    it("should work with a path and a set", () => {
       const deleted = new Set(["toto", "tata", "tutu"]);
       const { match, names, values } = actionMatch({
         action: deleteFrom(path("attr.name"), value(deleted)),
+        matcher: /(#\S+)\s+(:\S+)/,
+      });
+      expect(match[1]).to.equal(names.substitute("attr.name"));
+      expect(match[2]).to.equal(values.substitute(deleted));
+    });
+    it("should work with an implicit path and a set", () => {
+      const deleted = new Set(["toto", "tata", "tutu"]);
+      const { match, names, values } = actionMatch({
+        action: deleteFrom("attr.name", value(deleted)),
         matcher: /(#\S+)\s+(:\S+)/,
       });
       expect(match[1]).to.equal(names.substitute("attr.name"));

--- a/test/unit/commands/expressions/update/if-not-exists.spec.ts
+++ b/test/unit/commands/expressions/update/if-not-exists.spec.ts
@@ -4,7 +4,7 @@ import { operandMatch } from "./action-match.js";
 
 describe("commands.expressions.update.if-not-exists", () => {
   describe(ifNotExists.name, () => {
-    it("should work with an attribute name as default value", () => {
+    it("should work with a path as lhs and a path as default", () => {
       const attribute = "attr.path";
       const defaultAttribute = "attr.defaultPath";
       const { match, names } = operandMatch({
@@ -15,7 +15,18 @@ describe("commands.expressions.update.if-not-exists", () => {
       expect(match[1]).to.equal(names.substitute(attribute));
       expect(match[2]).to.equal(names.substitute(defaultAttribute));
     });
-    it("should work with an attribute value as default value", () => {
+    it("should work with an implicit path as lhs and a path as default", () => {
+      const attribute = "attr.path";
+      const defaultAttribute = "attr.defaultPath";
+      const { match, names } = operandMatch({
+        operand: ifNotExists(attribute, path(defaultAttribute)),
+        matcher: /if_not_exists\((#\S+),\s+(#\S+)\)/,
+      });
+
+      expect(match[1]).to.equal(names.substitute(attribute));
+      expect(match[2]).to.equal(names.substitute(defaultAttribute));
+    });
+    it("should work with a path as lhs and value as default", () => {
       const attribute = "attr.path";
       const defaultValue = [1, 2, 3];
       const { match, names, values } = operandMatch({

--- a/test/unit/commands/expressions/update/remove.spec.ts
+++ b/test/unit/commands/expressions/update/remove.spec.ts
@@ -4,11 +4,19 @@ import { actionMatch } from "./action-match.js";
 
 describe("commands.expressions.update.remove", () => {
   describe(remove.name, () => {
-    it("should work with an attribute name", () => {
+    it("should work with a path", () => {
       const attribute = "attr.path";
       const { match, names } = actionMatch({
         action: remove(path(attribute)),
         // Should only dispatch to the operand.
+        matcher: /(#\S+)/,
+      });
+      expect(match[1]).to.equal(names.substitute(attribute));
+    });
+    it("should work with an implicit path", () => {
+      const attribute = "attr.path";
+      const { match, names } = actionMatch({
+        action: remove(attribute),
         matcher: /(#\S+)/,
       });
       expect(match[1]).to.equal(names.substitute(attribute));

--- a/test/unit/commands/expressions/update/set.spec.ts
+++ b/test/unit/commands/expressions/update/set.spec.ts
@@ -4,7 +4,7 @@ import { actionMatch } from "./action-match.js";
 
 describe("commands.expressions.update.set", () => {
   describe(set.name, () => {
-    it("should work with an attribute name", () => {
+    it("should work with a path as lhs and a path as rhs", () => {
       const attribute = "attr.path";
       const operand = "attr.operand";
       const { match, names } = actionMatch({
@@ -14,7 +14,17 @@ describe("commands.expressions.update.set", () => {
       expect(match[1]).to.equal(names.substitute(attribute));
       expect(match[2]).to.equal(names.substitute(operand));
     });
-    it("should work with an attribute value", () => {
+    it("should work with an implicit path as lhs and a path as rhs", () => {
+      const attribute = "attr.path";
+      const operand = "attr.operand";
+      const { match, names } = actionMatch({
+        action: set(attribute, path(operand)),
+        matcher: /(#\S+)\s+=\s+(#\S+)/,
+      });
+      expect(match[1]).to.equal(names.substitute(attribute));
+      expect(match[2]).to.equal(names.substitute(operand));
+    });
+    it("should work with a value", () => {
       const attribute = "attr.path";
       const operand = 42;
       const { match, names, values } = actionMatch({


### PR DESCRIPTION
- Introduced the ability to substitute path operands with native
strings directly in APIs expecting Path operands only. The native
string types will always default to path operands and cannot be used
for value operands (they *have* to be wrapped).
